### PR TITLE
Switch SDK build to dual module format (CJS + ESM)

### DIFF
--- a/gen.yaml
+++ b/gen.yaml
@@ -65,7 +65,7 @@ typescript:
   maxMethodParams: 0
   methodArguments: require-security-and-request
   modelPropertyCasing: camel
-  moduleFormat: commonjs
+  moduleFormat: dual
   multipartArrayFormat: legacy
   outputModelSuffix: output
   packageName: '@unified-api/typescript-sdk'


### PR DESCRIPTION
### Summary
Update `gen.yaml` to use `moduleFormat: dual` to publish both CommonJS and ESM outputs. This improves compatibility and tree-shaking for consumers and avoids the packaging edge case that led to `2.81.0` missing the compiled `index.js` entrypoint.

### Why
- A customer reported `2.81.0` shipped sources only with `"main": "./index.js"` but no `index.js` present.
- While the underlying build issue is addressed upstream, adopting dual output is our recommended long-term approach for reliability and DX.

### Impact
- No runtime API changes.
- `require('@unified-api/typescript-sdk')` continues to work.
- `import ... from '@unified-api/typescript-sdk'` is now fully supported.
- Improves tree-shaking for ESM consumers.

### Change
- Set in `gen.yaml`:

```yaml
moduleFormat: dual
```

### Release notes
- Publish both CJS and ESM. No breaking changes expected for consumers. If you previously hit the `2.81.0` packaging issue, please update to the next release containing this change.
